### PR TITLE
Trigger query on input change instead of keyup.enter

### DIFF
--- a/src/views/ProblemRating.vue
+++ b/src/views/ProblemRating.vue
@@ -23,7 +23,7 @@
             <el-input
               :placeholder="$t('placeholder')"
               v-model="keyword"
-              @keyup.enter="query"
+              @change="query"
             />
           </el-form-item>
           <el-form-item :label="$t('contestNumber')">
@@ -33,7 +33,7 @@
               :max="9999"
               :controls="false"
               style="width: 80px"
-              @keyup.enter="query"
+              @change="query"
             />
           </el-form-item>
           <el-form-item :label="$t('ratingInterval')">
@@ -43,7 +43,7 @@
               :max="9999"
               :controls="false"
               style="width: 80px"
-              @keyup.enter="query"
+              @change="query"
             />
           </el-form-item>
           <el-form-item> - </el-form-item>
@@ -54,7 +54,7 @@
               :max="9999"
               :controls="false"
               style="width: 80px"
-              @keyup.enter="query"
+              @change="query"
             />
           </el-form-item>
           <el-form-item>


### PR DESCRIPTION
We should not use `@keyup.enter` as the method to update the filter.
Let's use `@change` event instead, which triggers the filtering function when the input box goes out of focus and the input is changed.
This also makes the site more mobile-friendly, as most mobile keyboards cannot do `keyup.enter`.